### PR TITLE
Fix invalid dates, remove initial browse list, default filter open

### DIFF
--- a/client/src/components/Browse.js
+++ b/client/src/components/Browse.js
@@ -23,7 +23,7 @@ class Browse extends React.Component {
       pickupAddress: '',
       totalPrice: 0,
       snackBarOpen: false,
-      filterOpen: false,
+      filterOpen: true,
       start_owner: null,
       end_owner: null,
       backButton: false,
@@ -207,17 +207,17 @@ class Browse extends React.Component {
     });
   }
 
-  componentDidMount() {
-    const todayJS = moment().startOf('day').toDate();
-    this.getWalks({
-      minDate: todayJS,
-      startDate: null,
-      duration: null,
-      pickupTime: null,
-      price: 100,
-      selectedSort: 'price',
-    });
-  }
+  // componentDidMount() {
+    // const todayJS = moment().startOf('day').toDate();
+    // this.getWalks({
+    //   minDate: todayJS,
+    //   startDate: null,
+    //   duration: null,
+    //   pickupTime: null,
+    //   price: 100,
+    //   selectedSort: 'price',
+    // });
+  // }
 
   handleSnackBarClose() {
     this.setState({

--- a/client/src/components/BrowseList.js
+++ b/client/src/components/BrowseList.js
@@ -7,9 +7,8 @@ class BrowseList extends React.Component {
     super(props);
   }
   render() {
-    var streetAddress = parser.parseLocation(this.props.ownerInfo.address);
     var title = {
-      'false': `Today's Walks Near ${streetAddress['number']} ${streetAddress['street']} ${streetAddress['type']}`,
+      'false': 'Open the filter to start searching for walks!',
       'true': 'Search Results'
     };
     return (

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -298,8 +298,8 @@ class Calendar extends React.Component {
           handleClose={this.handleFormClose}
           handleOpen={this.handleFormOpen}
           handleSubmit={this.handleSubmit}
-          start={this.state.start_walker}
-          end={this.state.end_walker}
+          start={this.state.start}
+          end={this.state.end}
           price={this.state.price}
           location={this.state.location}/>
         <EventDialog


### PR DESCRIPTION
- fix issue where walker scheduling walks is shown "invalid date to invalid date"
- remove initial list from browse as they cannot be booked (and show full time blocks > 2 hours)
- default filter drawer to open when going to Browse since the owner needs to fill out the filter before use